### PR TITLE
fix(ui): chart tooltips use bg-popover + shadow-sm

### DIFF
--- a/src/components/charts/activity-chart.tsx
+++ b/src/components/charts/activity-chart.tsx
@@ -42,7 +42,7 @@ function CustomTooltip({
     : "";
 
   return (
-    <div className="rounded-lg border border-border bg-background px-3 py-2 shadow-md">
+    <div className="rounded-[var(--radius-widget)] border border-border bg-popover p-2.5 shadow-sm">
       <p className="text-sm font-medium text-foreground mb-1">{date}</p>
       <p className="text-xs text-muted-foreground">
         {payload[0]?.value ?? 0} backup{(payload[0]?.value ?? 0) !== 1 ? "s" : ""}

--- a/src/components/charts/cron-chart.tsx
+++ b/src/components/charts/cron-chart.tsx
@@ -49,7 +49,7 @@ function CustomTooltip({
   const total = payload.reduce((sum, entry) => sum + (entry.value ?? 0), 0);
 
   return (
-    <div className="rounded-lg border border-border bg-background px-3 py-2 shadow-md">
+    <div className="rounded-[var(--radius-widget)] border border-border bg-popover p-2.5 shadow-sm">
       <p className="text-sm font-medium text-foreground mb-1">{date}</p>
       {payload.map((entry, i) => (
         <p key={i} className="text-xs text-muted-foreground flex items-center gap-1.5">

--- a/src/components/charts/project-charts.tsx
+++ b/src/components/charts/project-charts.tsx
@@ -61,7 +61,7 @@ function CustomTooltip({
   if (!active || !payload?.length) return null;
 
   return (
-    <div className="rounded-lg border border-border bg-background px-3 py-2 shadow-md">
+    <div className="rounded-[var(--radius-widget)] border border-border bg-popover p-2.5 shadow-sm">
       <p className="text-sm font-medium text-foreground mb-1">{label}</p>
       {payload.map((entry, i) => (
         <p key={i} className="text-xs text-muted-foreground">


### PR DESCRIPTION
Closes #4

## Changes
- `activity-chart.tsx`, `project-charts.tsx`, `cron-chart.tsx`: tooltip → `rounded-widget bg-popover border shadow-sm`

Per Basalt B05-5 popover pattern.