### PR TITLE
fix(ui): remove bg-input/border-input from button outline variant

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border border-border bg-secondary shadow-xs hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost:


### PR DESCRIPTION
Closes #8

## Changes
Remove `bg-input` / `border-input` from button outline variant per Basalt B05 rules.

- **button.tsx** outline: `dark:bg-input/30 dark:border-input` → `border-border bg-secondary`

Codex review: APPROVE (MUL-730)
