### PR TITLE
fix(sidebar): correct collapsed logo padding per B02-2c

### DIFF
--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -167,7 +167,7 @@ export function Sidebar() {
     >
       {collapsed ? (
         <div className="flex h-screen w-[68px] flex-col items-center">
-          <div className="flex h-14 w-full items-center justify-start pl-[22px]">
+          <div className="flex h-14 w-full items-center justify-start pl-6">
             <img
               src="/logo-24.png"
               alt="Backy"


### PR DESCRIPTION
收起态 sidebar logo padding 修正为 `pl-6` (24px)，符合 B02-2c 规范。

Closes #19
