### PR TITLE
fix(lint): add gitleaks to pre-commit, eslint config for cli

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,9 @@
 # G1: Static analysis (typecheck + lint on staged files)
+# G2 (secrets): gitleaks on commits ahead of upstream
 # L1: Unit tests + coverage gate
 # Sequential: G1 first to catch static issues before running tests
 
-bun run typecheck && bun run lint:staged && bun run test:coverage
+bun run typecheck \
+  && bun run lint:staged \
+  && bun run gate:secrets \
+  && bun run test:coverage

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
-# G2: Security gate (osv-scanner + gitleaks)
+# G2: Security gate (osv-scanner only — secrets are checked in pre-commit)
 #
 # L2 (API E2E) currently lives in apps/web_legacy only. After the
 # Vite + Worker cutover (docs/07 Wave E.1) the legacy E2E is no
@@ -6,4 +6,4 @@
 # step here once Wave B' lands streaming uploads + integration
 # tests on the worker.
 
-bun run gate:security
+bun run gate:deps

--- a/apps/cli/eslint.config.mjs
+++ b/apps/cli/eslint.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig, globalIgnores } from "eslint/config";
+import tseslint from "typescript-eslint";
+
+const eslintConfig = defineConfig([
+  ...tseslint.configs.strict.map((config) => ({
+    ...config,
+    files: ["**/*.ts"],
+  })),
+  {
+    files: ["**/__tests__/**", "**/*.test.*"],
+    rules: {
+      "@typescript-eslint/no-non-null-assertion": "off",
+    },
+  },
+  globalIgnores(["node_modules/**", "dist/**", "scripts/**"]),
+]);
+
+export default eslintConfig;

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,6 +7,8 @@
     "backy": "./src/bin.ts"
   },
   "scripts": {
+    "lint": "eslint --max-warnings=0 src",
+    "lint:staged": "lint-staged",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit"
@@ -14,7 +16,13 @@
   "devDependencies": {
     "@types/bun": "^1.3.11",
     "@vitest/coverage-v8": "^4.0.18",
+    "eslint": "^9.39.4",
+    "lint-staged": "^16.4.0",
     "typescript": "^5.9.3",
+    "typescript-eslint": "8.56.0",
     "vitest": "^4.0.18"
+  },
+  "lint-staged": {
+    "*.ts": "eslint --max-warnings=0 --no-warn-ignored"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -12,12 +12,15 @@
       "name": "@backy/cli",
       "version": "0.0.0",
       "bin": {
-        "backy": "./src/index.ts",
+        "backy": "./src/bin.ts",
       },
       "devDependencies": {
         "@types/bun": "^1.3.11",
         "@vitest/coverage-v8": "^4.0.18",
+        "eslint": "^9.39.4",
+        "lint-staged": "^16.4.0",
         "typescript": "^5.9.3",
+        "typescript-eslint": "8.56.0",
         "vitest": "^4.0.18",
       },
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test": "bun --cwd apps/web test && bun --cwd packages/api test && bun --cwd apps/worker test && bun --cwd apps/cli test",
     "test:coverage": "bun --cwd packages/api test:coverage && bun --cwd apps/worker test:coverage && bun --cwd apps/web test:coverage && bun --cwd apps/cli test:coverage",
     "gate:security": "bun run scripts/gate-security.ts",
+    "gate:secrets": "bun run scripts/gate-security.ts --secrets",
+    "gate:deps": "bun run scripts/gate-security.ts --deps",
     "release": "bun run scripts/release.ts",
     "web:dev": "bun --cwd apps/web dev",
     "web:build": "bun --cwd apps/web build",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "bun --cwd apps/worker dev & bun --cwd apps/web dev; wait",
     "build": "bun --cwd apps/web build",
-    "lint": "bun --cwd apps/web lint && bun --cwd packages/api lint && bun --cwd apps/worker lint",
-    "lint:staged": "bun --cwd apps/web lint:staged && bun --cwd packages/api lint:staged && bun --cwd apps/worker lint:staged",
+    "lint": "bun --cwd apps/web lint && bun --cwd packages/api lint && bun --cwd apps/worker lint && bun --cwd apps/cli lint",
+    "lint:staged": "bun --cwd apps/web lint:staged && bun --cwd packages/api lint:staged && bun --cwd apps/worker lint:staged && bun --cwd apps/cli lint:staged",
     "typecheck": "bun --cwd apps/web typecheck && bun --cwd packages/api typecheck && bun --cwd apps/worker typecheck && bun --cwd apps/cli typecheck",
     "test": "bun --cwd apps/web test && bun --cwd packages/api test && bun --cwd apps/worker test && bun --cwd apps/cli test",
     "test:coverage": "bun --cwd packages/api test:coverage && bun --cwd apps/worker test:coverage && bun --cwd apps/web test:coverage && bun --cwd apps/cli test:coverage",

--- a/scripts/gate-security.ts
+++ b/scripts/gate-security.ts
@@ -79,7 +79,7 @@ function resolveUpstreamRange(): { range: string; fallback: boolean } {
   return { range: "-20", fallback: true };
 }
 
-async function runGitleaks(): Promise<ScanResult> {
+async function runGitleaks(staged: boolean): Promise<ScanResult> {
   const name = "gitleaks";
   if (!toolExists(name)) {
     return {
@@ -90,6 +90,20 @@ async function runGitleaks(): Promise<ScanResult> {
     };
   }
 
+  if (staged) {
+    try {
+      const result = await $`gitleaks protect --staged --no-banner 2>&1`.quiet().nothrow();
+      const output = result.text();
+
+      if (result.exitCode === 0) {
+        return { name, ok: true, warn: false, output: `✅ ${name}: no secrets detected (staged)` };
+      }
+      return { name, ok: false, warn: false, output: `❌ ${name}: secrets detected (staged)\n${output}` };
+    } catch (err) {
+      return { name, ok: false, warn: false, output: `❌ ${name}: unexpected error — ${err}` };
+    }
+  }
+
   const { range, fallback } = resolveUpstreamRange();
   const mode = fallback ? "last 20 commits (no upstream)" : range;
 
@@ -97,7 +111,6 @@ async function runGitleaks(): Promise<ScanResult> {
     const result = await $`gitleaks git --log-opts=${range} --no-banner 2>&1`.quiet().nothrow();
     const output = result.text();
 
-    // gitleaks exits 0 = no leaks, 1 = leaks found
     if (result.exitCode === 0) {
       return { name, ok: true, warn: false, output: `✅ ${name}: no secrets detected (${mode})` };
     }
@@ -117,7 +130,7 @@ async function main(): Promise<void> {
 
   const tasks: Array<Promise<ScanResult>> = [];
   if (runBoth || onlyDeps) tasks.push(runOsvScanner());
-  if (runBoth || onlySecrets) tasks.push(runGitleaks());
+  if (runBoth || onlySecrets) tasks.push(runGitleaks(onlySecrets));
 
   const results = await Promise.all(tasks);
 

--- a/scripts/gate-security.ts
+++ b/scripts/gate-security.ts
@@ -108,9 +108,18 @@ async function runGitleaks(): Promise<ScanResult> {
 }
 
 async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const onlySecrets = args.includes("--secrets");
+  const onlyDeps = args.includes("--deps");
+  const runBoth = !onlySecrets && !onlyDeps;
+
   console.log("🔒 G2 Security Gate\n");
 
-  const results = await Promise.all([runOsvScanner(), runGitleaks()]);
+  const tasks: Array<Promise<ScanResult>> = [];
+  if (runBoth || onlyDeps) tasks.push(runOsvScanner());
+  if (runBoth || onlySecrets) tasks.push(runGitleaks());
+
+  const results = await Promise.all(tasks);
 
   for (const r of results) {
     console.log(r.output);


### PR DESCRIPTION
## Changes

### 1. Split gate:security into gate:secrets + gate:deps
- `gate:secrets`: runs `gitleaks protect --staged` (scans staged changes before commit)
- `gate:deps`: runs `osv-scanner` only
- `gate:security`: unchanged (runs both with commit-range gitleaks)

### 2. Update git hooks
- **pre-commit**: added `gate:secrets` (gitleaks on staged files) between lint:staged and test:coverage
- **pre-push**: changed from `gate:security` to `gate:deps` (secrets already caught in pre-commit)

### 3. Add eslint config for apps/cli
- Added `eslint.config.mjs` with strict TypeScript ESLint (matching web/worker/api)
- Added lint/lint:staged scripts to apps/cli package.json
- Updated root fan-out scripts to include apps/cli

Follows dove (标杆) project patterns.