### PR TITLE
style: fix HTML title language to match UI ("backy - AI Backup Service")

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -9,7 +9,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=DM+Sans:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <title>backy - AI 备份服务</title>
+    <title>backy - AI Backup Service</title>
     <meta
       name="description"
       content="Receive, store, preview, and restore backups sent by AI agents"


### PR DESCRIPTION
Fix HTML title to use English to match the English-only UI.\n\nChanges title to: `backy - AI Backup Service`