### PR TITLE
deps: bump 4 minor/patch dependencies (#50-#53)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260609.1",
+    "@cloudflare/workers-types": "^4.20260610.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.4.1",

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260609.1",
+        "@cloudflare/workers-types": "^4.20260610.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.4.1",

--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
       "name": "@backy/api",
       "version": "0.0.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1065.0",
+        "@aws-sdk/client-s3": "^3.1066.0",
         "@aws-sdk/s3-request-presigner": "^3.1065.0",
         "jszip": "^3.10.1",
         "nanoid": "^5.1.11",

--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
-        "@types/node": "^25.9.2",
+        "@types/node": "^25.9.3",
         "@types/tar-stream": "^3.1.4",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.4.1",
@@ -674,7 +674,7 @@
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
-    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
@@ -1263,6 +1263,12 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "buffer-image-size/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "bun-types/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
+
+    "happy-dom/@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "lint-staged/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1066.0",
-        "@aws-sdk/s3-request-presigner": "^3.1065.0",
+        "@aws-sdk/s3-request-presigner": "^3.1066.0",
         "jszip": "^3.10.1",
         "nanoid": "^5.1.11",
         "tar-stream": "^3.2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,7 +39,7 @@
     "./handlers/webhook": "./src/handlers/webhook.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1065.0",
+    "@aws-sdk/client-s3": "^3.1066.0",
     "@aws-sdk/s3-request-presigner": "^3.1065.0",
     "jszip": "^3.10.1",
     "nanoid": "^5.1.11",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1066.0",
-    "@aws-sdk/s3-request-presigner": "^3.1065.0",
+    "@aws-sdk/s3-request-presigner": "^3.1066.0",
     "jszip": "^3.10.1",
     "nanoid": "^5.1.11",
     "tar-stream": "^3.2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",
-    "@types/node": "^25.9.2",
+    "@types/node": "^25.9.3",
     "@types/tar-stream": "^3.1.4",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.4.1",


### PR DESCRIPTION
## Summary

Bumps 4 small dependencies surfaced by Choko on 2026-06-11. All minor/patch versions, no breaking changes.

### packages/api
- `@aws-sdk/client-s3` 3.1065.0 → 3.1066.0 (Closes #50)
- `@aws-sdk/s3-request-presigner` 3.1065.0 → 3.1066.0 (Closes #51)
- `@types/node` 25.9.2 → 25.9.3 (Closes #53)

### apps/worker
- `@cloudflare/workers-types` 4.20260609.1 → 4.20260610.1 (Closes #52)

> **Note**: #48 (`wrangler 4.98 → 4.99`) is NOT in this PR. The 4.99.0 [assets] SPA root regression on CI Linux runners (documented in #48) has not been resolved upstream — npm latest is still 4.99.0. Validating separately and will reopen as a standalone PR if a path forward exists.

## Verification

- `bun install` clean
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅ 704/704 (45 files)
- pre-push hook (L2 E2E + G2 osv-scanner/gitleaks) ✅