### PR TITLE
deps: bump aws-sdk s3 trio + workers-types (2026-06-12)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260610.1",
+    "@cloudflare/workers-types": "4.20260611.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.4.1",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260611.1",
+    "@cloudflare/workers-types": "^4.20260611.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.4.1",

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260610.1",
+        "@cloudflare/workers-types": "4.20260611.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.4.1",
@@ -208,7 +208,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260603.1", "", { "os": "win32", "cpu": "x64" }, "sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260610.1", "", {}, "sha512-Mk/f3lUygeIHzQ4HnJjU/JvGg/kllgp9gISty9nylHE/2M2MFeKO+hgAKSgiPpmwUbuhewdYGgqFGgT/ADK0/g=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260611.1", "", {}, "sha512-DLiz8Ol1OIWLigJ+dGvuQ5Nm66D/CHNPasl8YnPiz6fGo10ggYSIVuEDMlFk6oho+piAHstNmZMl088w8xqW6g=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260611.1",
+        "@cloudflare/workers-types": "^4.20260611.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.4.1",
@@ -89,8 +89,8 @@
       "name": "@backy/api",
       "version": "0.0.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "3.1067.0",
-        "@aws-sdk/s3-request-presigner": "3.1067.0",
+        "@aws-sdk/client-s3": "^3.1067.0",
+        "@aws-sdk/s3-request-presigner": "^3.1067.0",
         "jszip": "^3.10.1",
         "nanoid": "^5.1.11",
         "tar-stream": "^3.2.0",

--- a/bun.lock
+++ b/bun.lock
@@ -90,7 +90,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "3.1067.0",
-        "@aws-sdk/s3-request-presigner": "^3.1066.0",
+        "@aws-sdk/s3-request-presigner": "3.1067.0",
         "jszip": "^3.10.1",
         "nanoid": "^5.1.11",
         "tar-stream": "^3.2.0",
@@ -158,7 +158,7 @@
 
     "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.20", "", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.20", "@aws-sdk/signature-v4-multi-region": "^3.996.34", "@aws-sdk/types": "^3.973.12", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA=="],
 
-    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1066.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.20", "@aws-sdk/signature-v4-multi-region": "^3.996.34", "@aws-sdk/types": "^3.973.12", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-hgjGUVKggCKcwS+e7HOoHlElQrhz4nlZkMWGKez/Ycjv2qZaQeTZ8Ps7HGOrpqR3KBPWt7iSrOBcOCVoUYYRWw=="],
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1067.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.20", "@aws-sdk/signature-v4-multi-region": "^3.996.34", "@aws-sdk/types": "^3.973.12", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-BXoy6vCLR/ns2a09knkFgs18fX+EozyOsxX/eHwEXH3DgRh/w2z24X3bamU0ouc5DAGQRKmLeRcYKd7YasmcpQ=="],
 
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.34", "", { "dependencies": { "@aws-sdk/types": "^3.973.12", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -89,7 +89,7 @@
       "name": "@backy/api",
       "version": "0.0.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1066.0",
+        "@aws-sdk/client-s3": "3.1067.0",
         "@aws-sdk/s3-request-presigner": "^3.1066.0",
         "jszip": "^3.10.1",
         "nanoid": "^5.1.11",
@@ -132,7 +132,7 @@
 
     "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.5", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@aws-crypto/crc32c": "5.2.0", "@aws-crypto/util": "5.2.0", "@aws-sdk/core": "^3.974.20", "@aws-sdk/types": "^3.973.12", "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-zOXUUnilC6lgCsQtp77p/QNPmRlTES9Xi6tlDwbR6kfC/kz5PCzZckgHWm5z+8DskdwuMAbFDq61x3zr10GEEQ=="],
 
-    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1066.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.20", "@aws-sdk/credential-provider-node": "^3.972.55", "@aws-sdk/middleware-flexible-checksums": "^3.974.30", "@aws-sdk/middleware-sdk-s3": "^3.972.51", "@aws-sdk/signature-v4-multi-region": "^3.996.34", "@aws-sdk/types": "^3.973.12", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-jfJTg6Xbyws8+YF5sVQXgCA01elkenGEYeX6+HQOovu9m/Td1Ln2xcY3lHKetVNltdArp5rykjNd56z7bnA9dw=="],
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1067.0", "", { "dependencies": { "@aws-crypto/sha1-browser": "5.2.0", "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.20", "@aws-sdk/credential-provider-node": "^3.972.55", "@aws-sdk/middleware-flexible-checksums": "^3.974.30", "@aws-sdk/middleware-sdk-s3": "^3.972.51", "@aws-sdk/signature-v4-multi-region": "^3.996.34", "@aws-sdk/types": "^3.973.12", "@smithy/core": "^3.24.6", "@smithy/fetch-http-handler": "^5.4.6", "@smithy/node-http-handler": "^4.7.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-3f64o9YWzwJ9WzMIC4JlUQiMOm7R/EtkIDyFdj8yaQXuh8SR9ezz2R32UMpvTlVMtpoPan3Uj8oveAHr2UeExw=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.974.20", "", { "dependencies": { "@aws-sdk/types": "^3.973.12", "@aws-sdk/xml-builder": "^3.972.29", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,7 +39,7 @@
     "./handlers/webhook": "./src/handlers/webhook.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1066.0",
+    "@aws-sdk/client-s3": "3.1067.0",
     "@aws-sdk/s3-request-presigner": "^3.1066.0",
     "jszip": "^3.10.1",
     "nanoid": "^5.1.11",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,8 +39,8 @@
     "./handlers/webhook": "./src/handlers/webhook.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "3.1067.0",
-    "@aws-sdk/s3-request-presigner": "3.1067.0",
+    "@aws-sdk/client-s3": "^3.1067.0",
+    "@aws-sdk/s3-request-presigner": "^3.1067.0",
     "jszip": "^3.10.1",
     "nanoid": "^5.1.11",
     "tar-stream": "^3.2.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.1067.0",
-    "@aws-sdk/s3-request-presigner": "^3.1066.0",
+    "@aws-sdk/s3-request-presigner": "3.1067.0",
     "jszip": "^3.10.1",
     "nanoid": "^5.1.11",
     "tar-stream": "^3.2.0",


### PR DESCRIPTION
## Summary

Routine dependency upgrades from `[🥝 choko]` auto-scan (2026-06-12 batch):

| Package | Workspace | From | To | GH issue |
|---|---|---|---|---|
| `@aws-sdk/client-s3` | `packages/api` deps | `3.1066.0` | `3.1067.0` | #56 |
| `@aws-sdk/s3-request-presigner` | `packages/api` deps | `3.1066.0` | `3.1067.0` | #57 |
| `@cloudflare/workers-types` | `apps/worker` devDeps | `4.20260610.1` | `4.20260611.1` | #58 |

Manifest semver策略保持现有 caret range，与历史依赖升级（`56ea866` / `081fe3b` / `5f5d548`）一致。

Wrangler `4.100.0` (#59) 暂未升级，原因见 #48 的 STU-392 记录：`[assets] not_found_handling = single-page-application` 在 wrangler 4.99.0+ 下的 SPA fallback 会返回空 body / 404，本地 macOS 也能稳定复现，等上游修复。

Closes #56
Closes #57
Closes #58

## Test plan

- [x] G1: `bun run typecheck` (web / api / worker / cli)
- [x] L1: `bun run lint` (eslint --max-warnings=0)
- [x] L1: `bun run test` (45 files, 704 tests)
- [x] G2: `bun run gate:security` (osv-scanner + gitleaks)
- [x] L2: `bun run test:e2e:api` (pre-push hook)
- [ ] L3: `bun run test:e2e:bdd` (CI; not related to these dep surfaces)