### PR TITLE
deps(worker): bump @cloudflare/workers-types to 4.20260613.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260612.1",
+    "@cloudflare/workers-types": "^4.20260613.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.5.0",

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260612.1",
+        "@cloudflare/workers-types": "^4.20260613.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.5.0",
@@ -209,7 +209,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260603.1", "", { "os": "win32", "cpu": "x64" }, "sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260612.1", "", {}, "sha512-PMQI7XP/wrMhxyjseUHoHj6XFqkHaf4utWQ/hhefVY8oMK2LJ730oeQ7H/nZSVMexZe39DzsdOx7sf1PqMr7+Q=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260613.1", "", {}, "sha512-1mrgjE6epolwBhroeGAp5ud5H6Vyi6tl1o/NP0T4rXJ8bmEjmhHnbCzAhHTDHV0PIeip43wcuzHKJarvaGTaUA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Summary
- Bumps `@cloudflare/workers-types` from `4.20260612.1` to `4.20260613.1` in `apps/worker` (devDependencies).
- Keeps the caret range (`^4.20260613.1`) consistent with the prior STU-530 fix.
- `bun.lock` regenerated.

Closes nocoo/backy#72.

## Test plan
- [x] G1 typecheck: `bun run typecheck`
- [x] G1 lint: `bun run lint`
- [x] L1 unit tests + coverage: `bun run test:coverage` (704/704 pass, stmts 97.96%)
- [x] G2 secrets: clean
- [x] L2 route coverage gate: 39/39
- [x] L3 page coverage gate: 8/8