### PR TITLE
deps: weekly bump (workers-types, lint-staged, nanoid)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -17,7 +17,7 @@
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.5.0",
-    "lint-staged": "^17.0.7",
+    "lint-staged": "^17.0.8",
     "typescript": "^6.0.3",
     "typescript-eslint": "8.61.1",
     "vitest": "^4.1.9"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,7 @@
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.5.0",
     "happy-dom": "^20.10.6",
-    "lint-staged": "^17.0.7",
+    "lint-staged": "^17.0.8",
     "tailwindcss": "^4.3.1",
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -23,7 +23,7 @@
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.5.0",
-    "lint-staged": "^17.0.7",
+    "lint-staged": "^17.0.8",
     "typescript": "^6.0.3",
     "typescript-eslint": "8.61.1",
     "vitest": "^4.1.9",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260619.1",
+    "@cloudflare/workers-types": "^4.20260620.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.5.0",

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
-        "lint-staged": "17.0.8",
+        "lint-staged": "^17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.61.1",
         "vitest": "^4.1.9",
@@ -56,7 +56,7 @@
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
         "happy-dom": "^20.10.6",
-        "lint-staged": "17.0.8",
+        "lint-staged": "^17.0.8",
         "tailwindcss": "^4.3.1",
         "tw-animate-css": "^1.4.0",
         "typescript": "^6.0.3",
@@ -78,7 +78,7 @@
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
-        "lint-staged": "17.0.8",
+        "lint-staged": "^17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.61.1",
         "vitest": "^4.1.9",
@@ -92,7 +92,7 @@
         "@aws-sdk/client-s3": "^3.1073.0",
         "@aws-sdk/s3-request-presigner": "^3.1073.0",
         "jszip": "^3.10.1",
-        "nanoid": "^5.1.14",
+        "nanoid": "5.1.15",
         "tar-stream": "^3.2.0",
         "zod": "^4.4.3",
       },
@@ -102,7 +102,7 @@
         "@types/tar-stream": "^3.1.4",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
-        "lint-staged": "17.0.8",
+        "lint-staged": "^17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.61.1",
         "vitest": "^4.1.9",
@@ -967,7 +967,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.14", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-5c8l8kVzqpnDPaicbEop/fV0Q1w16FmbWtVhMqugTozAwYdlIQojWH5a/M7UfziFmGdQRrUdV+EPzc9Xng3VAQ=="],
+    "nanoid": ["nanoid@5.1.15", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kBg3RpGtIe+RpTbyXwoI6pk5yD7KUiI3sygUqgeBMRst42KmhB4RZC7eiO9Wa1HIpaCCtpE2DJ6OI4Wi5ebwFw=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260619.1",
+        "@cloudflare/workers-types": "4.20260620.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
-        "lint-staged": "^17.0.7",
+        "lint-staged": "17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.61.1",
         "vitest": "^4.1.9",
@@ -56,7 +56,7 @@
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
         "happy-dom": "^20.10.6",
-        "lint-staged": "^17.0.7",
+        "lint-staged": "17.0.8",
         "tailwindcss": "^4.3.1",
         "tw-animate-css": "^1.4.0",
         "typescript": "^6.0.3",
@@ -74,11 +74,11 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260620.1",
+        "@cloudflare/workers-types": "^4.20260620.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
-        "lint-staged": "^17.0.7",
+        "lint-staged": "17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.61.1",
         "vitest": "^4.1.9",
@@ -102,7 +102,7 @@
         "@types/tar-stream": "^3.1.4",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.5.0",
-        "lint-staged": "^17.0.7",
+        "lint-staged": "17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.61.1",
         "vitest": "^4.1.9",
@@ -941,7 +941,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "lint-staged": ["lint-staged@17.0.7", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-JrSobt+tW3rH8IOMi8tDZd3foorM5yPEkLD/V2NxobgHrFfHWGee4MOLVuZeScgxftEwbHrPHIFA/ZL+nUJeuA=="],
+    "lint-staged": ["lint-staged@17.0.8", "", { "dependencies": { "listr2": "^10.2.1", "picomatch": "^4.0.4", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA=="],
 
     "listr2": ["listr2@10.2.1", "", { "dependencies": { "cli-truncate": "^5.2.0", "eventemitter3": "^5.0.4", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^10.0.0" } }, "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -42,7 +42,7 @@
     "@aws-sdk/client-s3": "^3.1073.0",
     "@aws-sdk/s3-request-presigner": "^3.1073.0",
     "jszip": "^3.10.1",
-    "nanoid": "^5.1.14",
+    "nanoid": "^5.1.15",
     "tar-stream": "^3.2.0",
     "zod": "^4.4.3"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,7 +52,7 @@
     "@types/tar-stream": "^3.1.4",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.5.0",
-    "lint-staged": "^17.0.7",
+    "lint-staged": "^17.0.8",
     "typescript": "^6.0.3",
     "typescript-eslint": "8.61.1",
     "vitest": "^4.1.9"


### PR DESCRIPTION
## Summary

Weekly dependency bumps from 🥝 choko autopilot. Each dep is an atomic commit.

- `@cloudflare/workers-types` 4.20260619.1 → 4.20260620.1 (apps/worker)
- `lint-staged` 17.0.7 → 17.0.8 (apps/cli, apps/web, apps/worker, packages/api)
- `nanoid` 5.1.14 → 5.1.15 (packages/api)

Closes #115, closes #116, closes #117.

## Test plan

- [x] `bun run typecheck` (all 4 workspaces)
- [x] `bun run lint`
- [x] `bun run test:coverage` (45 files / 704 tests pass, coverage 97.96%)
- [x] `bun run test:e2e:api` (40/40)
- [x] `bun run gate:security` (osv-scanner + gitleaks clean)
