### PR TITLE
deps: bump eslint + workers-types (2026-06-27)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "lint-staged": "^17.0.8",
     "typescript": "^6.0.3",
     "typescript-eslint": "8.62.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -37,7 +37,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
     "@vitest/coverage-v8": "^4.1.9",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "happy-dom": "^20.10.6",
     "lint-staged": "^17.0.8",
     "tailwindcss": "^4.3.1",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "4.20260625.1",
+    "@cloudflare/workers-types": "4.20260626.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.6.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -22,7 +22,7 @@
     "@cloudflare/workers-types": "4.20260625.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "lint-staged": "^17.0.8",
     "typescript": "^6.0.3",
     "typescript-eslint": "8.62.0",

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
-        "eslint": "^10.5.0",
+        "eslint": "10.6.0",
         "lint-staged": "^17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.62.0",
@@ -54,7 +54,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
         "@vitest/coverage-v8": "^4.1.9",
-        "eslint": "^10.5.0",
+        "eslint": "10.6.0",
         "happy-dom": "^20.10.6",
         "lint-staged": "^17.0.8",
         "tailwindcss": "^4.3.1",
@@ -77,7 +77,7 @@
         "@cloudflare/workers-types": "4.20260625.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
-        "eslint": "^10.5.0",
+        "eslint": "10.6.0",
         "lint-staged": "^17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.62.0",
@@ -101,7 +101,7 @@
         "@types/node": "26.0.1",
         "@types/tar-stream": "^3.1.4",
         "@vitest/coverage-v8": "^4.1.9",
-        "eslint": "^10.5.0",
+        "eslint": "10.6.0",
         "lint-staged": "^17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.62.0",
@@ -799,7 +799,7 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "eslint": ["eslint@10.5.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ=="],
+    "eslint": ["eslint@10.6.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
-        "eslint": "10.6.0",
+        "eslint": "^10.6.0",
         "lint-staged": "^17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.62.0",
@@ -54,7 +54,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
         "@vitest/coverage-v8": "^4.1.9",
-        "eslint": "10.6.0",
+        "eslint": "^10.6.0",
         "happy-dom": "^20.10.6",
         "lint-staged": "^17.0.8",
         "tailwindcss": "^4.3.1",
@@ -74,10 +74,10 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "4.20260625.1",
+        "@cloudflare/workers-types": "4.20260626.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
-        "eslint": "10.6.0",
+        "eslint": "^10.6.0",
         "lint-staged": "^17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.62.0",
@@ -101,7 +101,7 @@
         "@types/node": "26.0.1",
         "@types/tar-stream": "^3.1.4",
         "@vitest/coverage-v8": "^4.1.9",
-        "eslint": "10.6.0",
+        "eslint": "^10.6.0",
         "lint-staged": "^17.0.8",
         "typescript": "^6.0.3",
         "typescript-eslint": "8.62.0",
@@ -211,7 +211,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260625.1", "", { "os": "win32", "cpu": "x64" }, "sha512-LH6iIX1HHaTwVKV5VokDxxUErXJzQoNZFRwVm7Vx/3fB/ApcTcRCUaMqcxI4as94jEUqg+pmX5czOndiveohow=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260625.1", "", {}, "sha512-asH0RhPHiNu/IUSssyiOJYAcGqysy0DJpO9fihC6KATaayD9CE1E9bgNQozTLUraxrCT2qkM4CBOIcV0M5NPJw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260626.1", "", {}, "sha512-fBnpQyFRS3Ce1l2IUd3k+aUxgy/7VMlVXF4F672/eSrpXFeezCy3Ha6Z2uTyGgqu9sGvQPOj8nqKBv2yeI+ciw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -51,7 +51,7 @@
     "@types/node": "26.0.1",
     "@types/tar-stream": "^3.1.4",
     "@vitest/coverage-v8": "^4.1.9",
-    "eslint": "^10.5.0",
+    "eslint": "^10.6.0",
     "lint-staged": "^17.0.8",
     "typescript": "^6.0.3",
     "typescript-eslint": "8.62.0",


### PR DESCRIPTION
## Summary

Daily dependency upgrade batch for 2026-06-27 (2 GitHub issues).

| Workspace | Package | From → To |
|---|---|---|
| `apps/cli`, `apps/web`, `apps/worker`, `packages/api` | `eslint` | `10.5.0` → `10.6.0` |
| `apps/worker` | `@cloudflare/workers-types` | `4.20260625.1` → `4.20260626.1` |

Both are minor `devDependencies` bumps. Atomic commit per GitHub issue; both commits preserved on this branch.

## Verification

- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅ (45 files / 704 tests pass)
- `bun audit` ✅ (clean, verified by Reviewer-03)
- Reviewer-03 approved on Multica STU-1339

Closes nocoo/backy#143
Closes nocoo/backy#142
