### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
## Summary

Add root `.npmrc` for supply chain security baseline: pin registry to official npmjs.org, enable audit (fail on high+), enforce lockfile integrity (`save-exact` + `package-lock`), and turn on `engine-strict` so occasional `npm`/`npx` invocations honor the engines field.

Content is byte-for-byte the template from [STU-1533](mention://issue/6a328527-41f2-4d78-8603-8c6772320f4b). No changes to `package.json`, `bun.lock`, `bunfig.toml`, CI, or hooks.

## Test plan

- [x] `git diff HEAD~1 --stat` shows only `.npmrc | 21 +++++++++++++++++++++`
- [x] `cat .npmrc` matches the template verbatim (comments and blank sections preserved)
- [ ] CI green on PR
