### PR TITLE
chore(deps): batch bump recharts + @cloudflare/workers-types (2026-07-05)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,7 +22,7 @@
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "react-router": "^8.1.0",
-    "recharts": "^3.9.1",
+    "recharts": "^3.9.2",
     "sonner": "^2.0.7",
     "swr": "^2.4.2",
     "tailwind-merge": "^3.6.0",

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260703.1",
+    "@cloudflare/workers-types": "5.20260704.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.6.0",

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260703.1",
+        "@cloudflare/workers-types": "5.20260704.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.6.0",
@@ -193,7 +193,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260701.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260703.1", "", {}, "sha512-FaX1NlA+XbCjR6c0v0dLqXLmSlWvnMDg2fneVOzOoHJM5XL8gwqoAv9T0I0Ev5f199bTsr7styYgT88j7RftwA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260704.1", "", {}, "sha512-3yhiCWzlWjkwtvZCTrvppLTSTEY+HkaBHJ9EXOEbuA4WQduCbZxgbCnVq/AWyojHrvhYXtKpqWdHA3UIIX3POQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "react-router": "^8.1.0",
-        "recharts": "^3.9.1",
+        "recharts": "^3.9.2",
         "sonner": "^2.0.7",
         "swr": "^2.4.2",
         "tailwind-merge": "^3.6.0",
@@ -999,7 +999,7 @@
 
     "readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
-    "recharts": ["recharts@3.9.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg=="],
+    "recharts": ["recharts@3.9.2", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^11.1.8", "react-redux": "8.x.x || 9.x.x", "reselect": "5.2.0", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw=="],
 
     "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
 


### PR DESCRIPTION
## Summary

Two independent patch/minor devDependency bumps in one PR per the batch upgrade convention.

- `apps/web`: `recharts` `3.9.1` → `3.9.2` (patch)
- `apps/worker`: `@cloudflare/workers-types` `5.20260703.1` → `5.20260704.1` (minor within v5)

Both are inside the current major and inside the existing caret ranges — no API surface change.

## Verification

Wiped install (`rm -rf` node_modules / `.next` semantics via fresh `bun install`) and ran the full local gate on the merged tree:

- `bun run typecheck` — clean across `apps/web`, `packages/api`, `apps/worker`, `apps/cli`
- `bun run lint` — 0 warnings across all workspaces (`--max-warnings=0`)
- `bun run test` — **704 / 704** passing across 45 files
- `bun run build` — vite build succeeded (SPA bundled into `apps/worker/static/`)
- Pre-push gate: `osv-scanner` — 0 vulnerabilities

## Atomic commits

1. `deps(web): bump recharts 3.9.1 → 3.9.2` — Closes nocoo/backy#181
2. `deps(worker): bump @cloudflare/workers-types 5.20260703.1 → 5.20260704.1` — Closes nocoo/backy#180

Closes #180
Closes #181
