### PR TITLE
deps(worker): bump @cloudflare/workers-types 5.20260710.1 → 5.20260711.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260710.1",
+    "@cloudflare/workers-types": "5.20260711.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.7.0",

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260710.1",
+        "@cloudflare/workers-types": "5.20260711.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.7.0",
@@ -193,7 +193,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260708.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260710.1", "", {}, "sha512-4ooaY2Pb5XGwDn8Fzm6jnTAJkIX0R5LBvL9euQpp2T58sQItlAQd9yivAlkwGhpY5cM1u81/9HaXwKAjXwtyzA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260711.1", "", {}, "sha512-yY6GXfyrHJa33EWaSzS5N56Lsll02kgHo4Qodz2l2DNl4L6L5yXBMZVMvcYArirdYA1xn+o8LKVRQGdRpmSMzA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Summary

Bump `@cloudflare/workers-types` in `apps/worker` from `5.20260710.1` to `5.20260711.1` (minor). Tracks GH issue #214.

## Verification

- `bun install --frozen-lockfile` — no changes
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test:coverage` ✅ (45 files / 704 tests, 97.96% statements)
- `bun audit` — clean
- G2 security gate — clean

## Notes on sibling issue #199 (typescript 6 → 7)

Not included in this PR. Try-upgrade in the same worktree passes typecheck + vitest, but `bun run lint` crashes because `@typescript-eslint/typescript-estree@8.63.0` pins peer `typescript >=4.8.4 <6.1.0` and its internals aren't TS 7-compatible. Upstream `typescript-eslint` (incl. alpha channel `8.63.1-alpha.10`) still has the same cap. GH #199 stays OPEN; re-attempt once upstream ships TS 7 support.

Closes #214.
