### PR TITLE
deps: batch 2026-07-13 — hono/workers-types/nanoid (typescript 6→7 blocked)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -15,11 +15,11 @@
   },
   "dependencies": {
     "@backy/api": "workspace:*",
-    "hono": "^4.12.29",
+    "hono": "^4.12.30",
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260711.1",
+    "@cloudflare/workers-types": "5.20260712.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.7.0",

--- a/bun.lock
+++ b/bun.lock
@@ -70,11 +70,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@backy/api": "workspace:*",
-        "hono": "^4.12.29",
+        "hono": "^4.12.30",
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260711.1",
+        "@cloudflare/workers-types": "5.20260712.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.7.0",
@@ -193,7 +193,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260708.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260711.1", "", {}, "sha512-yY6GXfyrHJa33EWaSzS5N56Lsll02kgHo4Qodz2l2DNl4L6L5yXBMZVMvcYArirdYA1xn+o8LKVRQGdRpmSMzA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260712.1", "", {}, "sha512-tkQ18Lz41EPXLzh4cSuIGQzztDVueuGfTcjlP4M7Qa0rfHpVBNItf3GRkd9O0JgiXs9csAwz/kVv7sjYXSoF2w=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -831,7 +831,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.12.29", "", {}, "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw=="],
+    "hono": ["hono@4.12.30", "", {}, "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -92,7 +92,7 @@
         "@aws-sdk/client-s3": "^3.1085.0",
         "@aws-sdk/s3-request-presigner": "^3.1085.0",
         "jszip": "^3.10.1",
-        "nanoid": "^5.1.16",
+        "nanoid": "^6.0.0",
         "tar-stream": "^3.2.0",
         "zod": "^4.4.3",
       },
@@ -937,7 +937,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.16", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ=="],
+    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -42,7 +42,7 @@
     "@aws-sdk/client-s3": "^3.1085.0",
     "@aws-sdk/s3-request-presigner": "^3.1085.0",
     "jszip": "^3.10.1",
-    "nanoid": "^5.1.16",
+    "nanoid": "^6.0.0",
     "tar-stream": "^3.2.0",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
## Batch 2026-07-13 — 依赖升级

### 已升级
- `hono` 4.12.29 → 4.12.30 (patch) — `apps/worker`. Closes #217
- `@cloudflare/workers-types` 5.20260711.1 → 5.20260712.1 (minor, pinned) — `apps/worker`. Closes #216
- `nanoid` 5.1.16 → 6.0.0 (**major**) — `packages/api`. Closes #218

### 未升级（阻塞，未 close）
- `typescript` 6.0.3 → 7.0.2 (#199) — `typescript-eslint@8.63.0` 的 peer 声明为 `typescript: '>=4.8.4 <6.1.0'`，升到 TS 7 会让 ESLint 直接抛 `Cannot read properties of undefined (reading 'Cjs')`，lint gate 挂掉。等 `typescript-eslint` 发布支持 TS 7 的版本再单独开 PR。

### 验证
- `bun run typecheck` — 4 个 workspace 全部通过
- `bun run lint` — 4 个 workspace 全部通过
- `vitest run`（per-workspace）— 45 files / 704 tests 全绿（web 11/58, api 27/540, worker 6/101, cli 1/5）
- `bun run test:e2e:api` — 40/40 通过（本地 SQLite + wrangler --local）
- `bun run gate:security` — osv-scanner + gitleaks 全部干净

### 提交
- `42a556f` deps(worker): hono + workers-types
- `b8b72d5` deps(api): nanoid 5→6
