### PR TITLE
STU-2040: deps: bump backy dependencies (2026-07-20)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "^6.2.3"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260718.1",
+    "@cloudflare/workers-types": "5.20260719.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.7.0",

--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
         "jose": "^6.2.3",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260718.1",
+        "@cloudflare/workers-types": "5.20260719.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.7.0",
@@ -193,7 +193,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260714.1", "", { "os": "win32", "cpu": "x64" }, "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260718.1", "", {}, "sha512-PSeVPF0ZPsqv7snSwiywQX/c4jNDSXClOvFwxWoVysoltQEr6oPnOh7oRh1GoAUnVxkzzrqXbsPRTxzb3LIbag=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260719.1", "", {}, "sha512-DcGasbfUuczQilc80vhL2MPPdWcaxWkx0hN5IW9UdNDBdrRvWcal3akSJ6Ccm7e8+/OGeR+8tYrqkykA3YGSZw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
STU-2040: deps: bump backy dependencies (2026-07-20)

Closes #251

## Changes

- `deps(worker): bump @cloudflare/workers-types 5.20260718.1 → 5.20260719.1` — daily generated types refresh (patch).

## Skipped from this batch

- **#252 `radix-ui 1.6.2 → 1.6.3`** — upstream aggregated re-export regression. 1.6.3 replaced per-primitive namespace re-exports with a runtime `_mergeNamespaces` helper, which erases the primitive namespace types (`SelectPrimitive.Root`, `CheckboxPrimitive.Root`, `DialogPrimitive.Root`, …) at type level. Result: 13 `TS7006` errors across `apps/web/src/pages/*` (implicit `any` on callback params like `onValueChange={(v) => …}`, `onCheckedChange={(checked) => …}`, `onOpenChange={(open) => …}`). Fix path either (a) annotate every call site or (b) rewrite each wrapper in `apps/web/src/components/ui/*` to import from `@radix-ui/react-*` sub-packages directly — both are scope creep for a patch bump. Leaving #252 open pending an upstream fix or a dedicated migration.

- **#199 `typescript 6.0.3 → 7.0.2`** — still blocked by `typescript-eslint@8.64.0` peer `typescript >=4.8.4 <6.1.0` (see [issue #199 blocker comment](https://github.com/nocoo/backy/issues/199#issuecomment-4941552689) and STU-1968 skip note). Latest canary `8.64.1-alpha.11` unchanged. G1 lint gate would fail on TS 7.

## Gates

- `bun run typecheck` — 4 workspaces clean.
- `bun run lint` — 4 workspaces clean, `--max-warnings=0`.
- `bun run test` — 704/704 across 45 files.
- `bun run test:e2e:api` — 40/40 L2 (local wrangler + SQLite).
- `bun run gate:security` — osv-scanner + gitleaks clean.

