### PR TITLE
STU-2203: deps: bump brace-expansion 5.0.8 + minimatch 10.2.5 (GHSA-mh99-v99m-4gvg)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -114,7 +114,7 @@
     "esbuild": "^0.28.1",
     "fast-xml-builder": "^1.1.7",
     "flatted": "^3.4.0",
-    "minimatch": "^9.0.7",
+    "minimatch": "^10.2.5",
     "picomatch": "^4.0.4",
     "sharp": "^0.35.0",
     "vite": "^8.1.5",
@@ -919,7 +919,7 @@
 
     "miniflare": ["miniflare@4.20260721.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260721.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-fBLaCxZ2i/nPH8iyLzvza0C8/sSF4sjD1ma1Skf+pkZVK0TlaW5ujHJlUHwcwR66v2JZt+Q28d4DCX/oaLG0cA=="],
 
-    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -110,7 +110,7 @@
     },
   },
   "overrides": {
-    "brace-expansion": "^2.1.2",
+    "brace-expansion": "^5.0.8",
     "esbuild": "^0.28.1",
     "fast-xml-builder": "^1.1.7",
     "flatted": "^3.4.0",
@@ -679,7 +679,7 @@
 
     "b4a": ["b4a@1.8.0", "", { "peerDependencies": { "react-native-b4a": "*" }, "optionalPeers": ["react-native-b4a"] }, "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg=="],
 
-    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "bare-events": ["bare-events@2.8.2", "", { "peerDependencies": { "bare-abort-controller": "*" }, "optionalPeers": ["bare-abort-controller"] }, "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ=="],
 
@@ -697,7 +697,7 @@
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
-    "brace-expansion": ["brace-expansion@2.1.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "overrides": {
     "minimatch": "^9.0.7",
-    "brace-expansion": "^2.1.2",
+    "brace-expansion": "^5.0.8",
     "flatted": "^3.4.0",
     "picomatch": "^4.0.4",
     "fast-xml-builder": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "vitest": "4.1.10"
   },
   "overrides": {
-    "minimatch": "^9.0.7",
+    "minimatch": "^10.2.5",
     "brace-expansion": "^5.0.8",
     "flatted": "^3.4.0",
     "picomatch": "^4.0.4",


### PR DESCRIPTION
## Summary

依赖升级批次 STU-2203 — 2 items。

**升级** (原子提交)：

- `deps: bump brace-expansion override 2.1.2 → 5.0.8 (GHSA-mh99-v99m-4gvg)` — 修复 high 级别 DoS via unbounded expansion length
- `deps: bump minimatch override 9.0.7 → 10.2.5 (compat with brace-expansion 5)` — `minimatch@9` 用 default 调用 `brace-expansion`，v5 已改成 named export；`minimatch@10.2.5` 声明 `brace-expansion ^5.0.5` 恢复兼容

活动闭包唯一解析：`minimatch@10.2.5 → brace-expansion@5.0.8 → balanced-match@4.0.4`。

**跳过** (上游阻塞)：

- typescript 6.0.3 → 7.0.2 (#199) — `typescript-eslint@8.65.0` (latest) 及 `8.65.1-alpha.7` (canary) peer 仍为 `typescript >=4.8.4 <6.1.0`，本仓 `lint --max-warnings=0` 无法过。GH #199 保持 open + `blocked`。

## Test plan

- [x] `bun install` — 冻结锁一致，工作树干净
- [x] `bun run typecheck` — 4 workspaces 全绿
- [x] `bun run lint` — 4 workspaces 全绿 (`--max-warnings=0`)
- [x] `bunx eslint 'src/**/*.{ts,tsx}' --max-warnings=0` × 4 workspaces (含 brace glob) — 全绿
- [x] `bun run test` — 45 files / 704 tests passed
- [x] `bun run gate:security` — osv-scanner + gitleaks clean

Closes #279
