### PR TITLE
STU-2533: bump swr to 2.5.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,7 @@
     "react-router": "^8.3.0",
     "recharts": "^3.10.1",
     "sonner": "^2.0.7",
-    "swr": "^2.4.2",
+    "swr": "2.5.0",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
         "react-router": "^8.3.0",
         "recharts": "^3.10.1",
         "sonner": "^2.0.7",
-        "swr": "^2.4.2",
+        "swr": "2.5.0",
         "tailwind-merge": "^3.6.0",
         "zod": "^4.4.3",
       },
@@ -932,7 +932,7 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "swr": ["swr@2.4.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw=="],
+    "swr": ["swr@2.5.0", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-W0GomadRJe9OfzIoRX0kZHhDSaRRfdiOUeH6uazgR05SibBhDNwfdTbhAxmFtObvkf59fFymo22mooKukosvNA=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 


### PR DESCRIPTION
## Summary

- bump `swr` from 2.4.2 to 2.5.0 in the web app
- refresh the Bun lockfile entry and integrity hash

## Validation

- `bun install --frozen-lockfile`
- `bun run test` (45 files, 704 tests)
- `bun --cwd apps/web test` (11 files, 58 tests)
- `bun run typecheck`
- `bun run lint`
- `bun run build`

Reviewer-01 approved commit `f8af31d` with no blockers. The dependency security gate still reports pre-existing `hono@4.12.33` and `undici@7.28.0` findings present in the parent lockfile; SWR is not included in the report.

Closes STU-2533
Closes #319
