### PR TITLE
STU-2532: override undici to 7.29.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
     "minimatch": "^10.2.5",
     "picomatch": "^4.0.4",
     "sharp": "^0.35.0",
+    "undici": "7.29.0",
     "vite": "^8.2.0",
     "ws": "^8.21.0",
   },
@@ -962,7 +963,7 @@
 
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
-    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "esbuild": "^0.28.1",
     "vite": "^8.2.0",
     "ws": "^8.21.0",
-    "sharp": "^0.35.0"
+    "sharp": "^0.35.0",
+    "undici": "7.29.0"
   },
   "trustedDependencies": [
     "@biomejs/biome"


### PR DESCRIPTION
## Summary

- force the transitive `undici` dependency to the patched `7.29.0` release
- refresh `bun.lock` so Wrangler/Miniflare resolve the secure version

## Verification

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (45 files, 704 tests)
- `bun run build`
- `bun why undici` resolves `7.29.0`

`gate:deps` no longer reports undici; its remaining finding is the pre-existing `hono@4.12.33` advisory.

Closes STU-2532
Closes #320
