### PR TITLE
STU-2534: bump nanoid to 6.0.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -85,7 +85,7 @@
         "@aws-sdk/client-s3": "^3.1101.0",
         "@aws-sdk/s3-request-presigner": "^3.1101.0",
         "jszip": "^3.10.1",
-        "nanoid": "^6.0.0",
+        "nanoid": "^6.0.1",
         "tar-stream": "^3.2.0",
         "zod": "^4.4.3",
       },
@@ -850,7 +850,7 @@
 
     "miniflare": ["miniflare@5.20260730.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.28.0", "workerd": "1.20260730.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-8/dspSXDshP6nSkCpjKO7BYc2qZoYSXm7iM+QxY7qJyJpAB3onnQSaiu0cvKJlfuMGwULl55hG69FJCcCMXU1Q=="],
 
-    "nanoid": ["nanoid@6.0.0", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ=="],
+    "nanoid": ["nanoid@6.0.1", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -42,7 +42,7 @@
     "@aws-sdk/client-s3": "^3.1101.0",
     "@aws-sdk/s3-request-presigner": "^3.1101.0",
     "jszip": "^3.10.1",
-    "nanoid": "^6.0.0",
+    "nanoid": "^6.0.1",
     "tar-stream": "^3.2.0",
     "zod": "^4.4.3"
   },


### PR DESCRIPTION
## Summary

- bump `nanoid` from `6.0.0` to `6.0.1` in the API workspace
- refresh the resolved version and integrity hash in `bun.lock`
- preserve the existing caret version policy

## Verification

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (45 files, 704 tests)
- `bun run gate:deps` (OSV: no vulnerabilities found)
- commit hooks: secrets, route/page coverage, and coverage gates
- reviewed and approved by Reviewer-01

Closes #318
Closes STU-2534
