### PR TITLE
STU-2535: bump jose to 6.2.8

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@backy/api": "workspace:*",
-    "hono": "^4.12.33",
+    "hono": "^4.13.0",
     "jose": "^6.2.8"
   },
   "devDependencies": {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@backy/api": "workspace:*",
     "hono": "^4.12.33",
-    "jose": "^6.2.7"
+    "jose": "^6.2.8"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "5.20260801.1",

--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
       "dependencies": {
         "@backy/api": "workspace:*",
         "hono": "^4.12.33",
-        "jose": "^6.2.7",
+        "jose": "^6.2.8",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "5.20260801.1",
@@ -803,7 +803,7 @@
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
-    "jose": ["jose@6.2.7", "", {}, "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w=="],
+    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@backy/api": "workspace:*",
-        "hono": "^4.12.33",
+        "hono": "^4.13.0",
         "jose": "^6.2.8",
       },
       "devDependencies": {
@@ -779,7 +779,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.12.33", "", {}, "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ=="],
+    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 


### PR DESCRIPTION
## Summary

- bump `jose` from 6.2.7 to 6.2.8 in the worker workspace
- bump `hono` from 4.12.33 to 4.13.0 as an independent baseline security fix
- retain the existing `undici@7.29.0` security override from current main

## Validation

- frozen install
- full repository lint and typecheck
- 45/45 test files, 704/704 tests
- coverage gate
- G2 security gate: OSV 0 vulnerabilities, gitleaks passed
- 39/39 route coverage and 8/8 page coverage

Closes STU-2535
Closes #317
