### PR TITLE
STU-2533: restore SWR caret range

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,7 @@
     "react-router": "^8.3.0",
     "recharts": "^3.10.1",
     "sonner": "^2.0.7",
-    "swr": "2.5.0",
+    "swr": "^2.5.0",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
         "react-router": "^8.3.0",
         "recharts": "^3.10.1",
         "sonner": "^2.0.7",
-        "swr": "2.5.0",
+        "swr": "^2.5.0",
         "tailwind-merge": "^3.6.0",
         "zod": "^4.4.3",
       },


### PR DESCRIPTION
## Summary

- restore the repository's caret version policy for `swr`
- keep the resolved package version at 2.5.0
- refresh the workspace declaration in `bun.lock`

## Validation

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (704 passed)
- `bun run build`
- `bun run gate:deps`

Follow-up to #326.
Closes STU-2533
