### PR TITLE
STU-2899: bump @types/node to 26.2.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.14",
-        "@types/node": "26.1.2",
+        "@types/node": "26.2.0",
         "@types/tar-stream": "^3.1.4",
         "@vitest/coverage-v8": "^4.1.9",
         "typescript": "7.0.2",
@@ -591,7 +591,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
+    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.14",
-    "@types/node": "26.1.2",
+    "@types/node": "26.2.0",
     "@types/tar-stream": "^3.1.4",
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "7.0.2",


### PR DESCRIPTION
## Summary

- bump `@types/node` in `packages/api` from 26.1.2 to 26.2.0
- refresh the Bun lockfile entry and integrity hash

## Validation

- API lint, typecheck, and 540 unit tests
- workspace lint, typecheck, build, and 704 coverage tests
- L2 API E2E: 40/40
- L3 Chromium BDD: 9/9
- `bun install --frozen-lockfile`

## Security gate note

The dependency gate currently reports pre-existing transitive `postcss/nanoid@3.3.16` (`GHSA-2v37-7h3g-55p8`). The same lockfile entry exists on `origin/main` and is outside this PR's diff.

Closes STU-2899
Closes #352
