### PR TITLE
STU-2897: bump hono to 4.13.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@backy/api": "workspace:*",
-    "hono": "^4.13.0",
+    "hono": "^4.13.1",
     "jose": "^6.2.8"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@backy/api": "workspace:*",
-        "hono": "^4.13.0",
+        "hono": "^4.13.1",
         "jose": "^6.2.8",
       },
       "devDependencies": {
@@ -779,7 +779,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.13.0", "", {}, "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ=="],
+    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1039,7 +1039,7 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "postcss/nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 


### PR DESCRIPTION
## Summary

- bump the worker's Hono dependency from `^4.13.0` to `^4.13.1`
- refresh the Bun lockfile to resolve `hono@4.13.1` with the published integrity
- preserve the repository's existing caret version policy
- resolve PostCSS's vulnerable transitive `nanoid` from `3.3.16` to the fixed `3.3.17` within its existing `^3.3.16` range

## Validation

- `bun install --frozen-lockfile`
- `bun run gate:security` — OSV and secrets checks pass
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test:coverage` — 704/704 tests, 97.96% statements
- `bun run test:e2e:api` — 40/40
- `bun run test:e2e:bdd` — 9/9
- route coverage 39/39 and page coverage 8/8

Closes #354
