### PR TITLE
STU-2895: bump nanoid to 3.3.17

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1039,7 +1039,7 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+    "postcss/nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
 
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 


### PR DESCRIPTION
## Summary

- update the `postcss`-scoped transitive `nanoid` lock entry from 3.3.16 to the security-fixed 3.3.17
- keep the direct `nanoid` 6.0.1 dependency unchanged

## Verification

- `bun install --frozen-lockfile`
- `bun why nanoid`
- `bun run gate:deps`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- `bun run test:coverage` (704 tests passed)

Closes #356
