### PR TITLE
STU-3098: bump workers types to 5.20260809.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -18,7 +18,7 @@
     "jose": "^6.2.8"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260808.1",
+    "@cloudflare/workers-types": "5.20260809.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "7.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
         "jose": "^6.2.8",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260808.1",
+        "@cloudflare/workers-types": "5.20260809.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "typescript": "7.0.2",
@@ -207,7 +207,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260808.1", "", {}, "sha512-DN7G9SMyeOq031YhQexoExFAK78ms74cFiFF1teDlTK4+LjHgIc5Z8VbvXQtcCIP//o38btxzxW0b9MGPA83CA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260809.1", "", {}, "sha512-sBM+0I5lCY9LgTnorn/N2UyrA6KVbUzj9tncxwH8v6sH8tVeAyJj+i0z3xXWY4l4fd1oDcwt8CGf50vGwVISYQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Summary

- bump `@cloudflare/workers-types` from `5.20260808.1` to `5.20260809.1`
- refresh the Bun lockfile entry and integrity hash

## Validation

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run typecheck`
- `bun run test` (45 files, 704 tests)
- `bun run build`
- `bun run gate:deps`

Closes STU-3098
Closes #367
