### PR TITLE
STU-3106: chore(deps): bump workers types to 5.20260810.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -18,7 +18,7 @@
     "jose": "^6.2.8"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260809.1",
+    "@cloudflare/workers-types": "5.20260810.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "7.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
         "jose": "^6.2.8",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260809.1",
+        "@cloudflare/workers-types": "5.20260810.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "typescript": "7.0.2",
@@ -207,7 +207,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260809.1", "", {}, "sha512-sBM+0I5lCY9LgTnorn/N2UyrA6KVbUzj9tncxwH8v6sH8tVeAyJj+i0z3xXWY4l4fd1oDcwt8CGf50vGwVISYQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260810.1", "", {}, "sha512-aD0hEU6HaiG4wy4hDoPoLXMH963nHD4MsIY566pGkWO2dL/yeYEiMN7SeJ24t+wBmLDnh16yQ7IPos5opGkIoA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Summary
- Bump `@cloudflare/workers-types` from 5.20260809.1 to 5.20260810.1 in `@backy/worker`
- Lockfile integrity updated; no application code changes

## Test plan
- [x] `bun --cwd apps/worker typecheck`
- [x] `bun --cwd apps/worker test` (101/101)
- [x] Pre-commit full suite (704/704, lint, security gates)
- [x] Reviewer-01 independent re-verification passed

Closes #370