### PR TITLE
STU-3262: chore(deps) bump workers-types to 5.20260811.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -18,7 +18,7 @@
     "jose": "^6.2.8"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260810.1",
+    "@cloudflare/workers-types": "5.20260811.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "7.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
         "jose": "^6.2.8",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260810.1",
+        "@cloudflare/workers-types": "5.20260811.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "typescript": "7.0.2",
@@ -207,7 +207,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260810.1", "", {}, "sha512-aD0hEU6HaiG4wy4hDoPoLXMH963nHD4MsIY566pGkWO2dL/yeYEiMN7SeJ24t+wBmLDnh16yQ7IPos5opGkIoA=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260811.1", "", {}, "sha512-jS3o9240P8t7Y/2lecXPC0rGdODZgHyFTWy9Asdm8htE2Uepx4PAvbcVo3EC0r8wZuv6rahDc1MMj+3nDZj/QA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Summary

- Bump `@cloudflare/workers-types` `5.20260810.1` → `5.20260811.1` in `apps/worker`
- Patch-only types devDependency; no runtime change
- Atomic commit on branch `agent/sde-01/ae668a02`

## Test plan

- [x] `bun --cwd apps/worker typecheck`
- [x] `bun --cwd apps/worker test` (101 passed)
- [x] `bun run test` (704 passed / 45 files)
- [x] `bun run typecheck` (web / api / worker / cli)
- [x] pre-commit gates (lint-staged, secrets, route/page coverage, coverage)
- [x] Reviewer-01 approved local commit (rebased to `e32d9b1` on latest main)

Closes STU-3262
Closes #378

Note: PR #381 also batches this bump with wrangler 4.120.1; this PR is the independent STU-3262 path approved by Reviewer-01.