### PR TITLE
STU-3382: chore(deps): bump swr to 2.5.1

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -23,7 +23,7 @@
     "react-router": "^8.3.0",
     "recharts": "^3.10.1",
     "sonner": "^2.0.8",
-    "swr": "^2.5.0",
+    "swr": "^2.5.1",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.4.3"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
         "react-router": "^8.3.0",
         "recharts": "^3.10.1",
         "sonner": "^2.0.8",
-        "swr": "^2.5.0",
+        "swr": "^2.5.1",
         "tailwind-merge": "^3.6.0",
         "zod": "^4.4.3",
       },
@@ -933,7 +933,7 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "swr": ["swr@2.5.0", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-W0GomadRJe9OfzIoRX0kZHhDSaRRfdiOUeH6uazgR05SibBhDNwfdTbhAxmFtObvkf59fFymo22mooKukosvNA=="],
+    "swr": ["swr@2.5.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-BRw55e8r0B7SpDN20CAzoQAHl7y1yP7/Zt7oqUjMv0vSt2u2Xnkm88Ws+VypbV9BXHQVuSuyVq7zMjO16wSExw=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 


### PR DESCRIPTION
## Summary
- Bump `swr` from `^2.5.0` to `^2.5.1` in `apps/web`
- Update `bun.lock` (resolved to `swr@2.5.1`)

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (45 files / 704 tests)
- [x] pre-commit gates (secrets / routes / pages / coverage)

Closes STU-3382
Closes #397