### PR TITLE
STU-3491: fix(deps): bump transitive nanoid to 3.3.18

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1037,7 +1037,7 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "postcss/nanoid": ["nanoid@3.3.17", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g=="],
+    "postcss/nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
 
     "sharp/semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 


### PR DESCRIPTION
Closes STU-3491

## Summary
- Bump transitive `postcss/nanoid` from `3.3.17` → `3.3.18` (GHSA-2v37-7h3g-55p8)
- Direct `nanoid@^6.0.1` in `@backy/api` unchanged
- Unblocks `gate:deps` / pre-push security gate

## Test plan
- [x] `bun run gate:deps` (clean)
- [x] pre-commit full suite (typecheck + coverage 704 tests)

Closes #407