### PR TITLE
STU-3490: chore(deps): bump hono to 4.13.2

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@backy/api": "workspace:*",
-    "hono": "^4.13.1",
+    "hono": "^4.13.2",
     "jose": "^6.2.8"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@backy/api": "workspace:*",
-        "hono": "^4.13.1",
+        "hono": "^4.13.2",
         "jose": "^6.2.8",
       },
       "devDependencies": {
@@ -779,7 +779,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.13.1", "", {}, "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw=="],
+    "hono": ["hono@4.13.2", "", {}, "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 


### PR DESCRIPTION
Closes STU-3490

## Summary
- Bump `hono` from `^4.13.1` to `^4.13.2` in `@backy/worker`
- Patch release; no breaking API changes observed

## Test plan
- [x] `bun --cwd apps/worker typecheck`
- [x] `bun --cwd apps/worker test` (101 passed)
- [x] `bun run gate:deps`

Closes #406