### PR TITLE
STU-3654: chore(deps): bump jose 6.2.8 → 6.2.9

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@backy/api": "workspace:*",
     "hono": "^4.13.2",
-    "jose": "^6.2.8"
+    "jose": "6.2.9"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "5.20260817.1",

--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
       "dependencies": {
         "@backy/api": "workspace:*",
         "hono": "^4.13.2",
-        "jose": "^6.2.8",
+        "jose": "6.2.9",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "5.20260817.1",
@@ -803,7 +803,7 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
+    "jose": ["jose@6.2.9", "", {}, "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 


### PR DESCRIPTION
## Summary

- Bump `jose` from `6.2.8` to `6.2.9` in `apps/worker` (Cloudflare Access JWT verification).
- Patch-only dependency update; no application code changes.

Closes STU-3654
Closes #419

## Test plan

- [x] `bun --cwd apps/worker test src/__tests__/access-auth.test.ts` — 16/16 passed
- [x] Pre-commit hooks: typecheck, lint-staged, G2 secrets, route/page coverage gates
- [x] Full unit suite with coverage: 704/704 passed
- [x] `gate:deps` (osv-scanner) clean
- [x] `bun.lock` clean (no mirror URLs)