### PR TITLE
STU-3682: chore(deps): bump workers-types to 5.20260818.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -18,7 +18,7 @@
     "jose": "^6.2.8"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260817.1",
+    "@cloudflare/workers-types": "5.20260818.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "7.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
         "jose": "^6.2.8",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260817.1",
+        "@cloudflare/workers-types": "5.20260818.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "typescript": "7.0.2",
@@ -207,7 +207,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260811.1", "", { "os": "win32", "cpu": "x64" }, "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260817.1", "", {}, "sha512-5Dv+cyjusBTPLMRedUCiLJu3zqeeupgyn1QcHmpHJV9k/TjQAxx79AO8RVtpjVaO2CB+Oh3ywAp1UuNpbyDjGQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260818.1", "", {}, "sha512-a89taQDbqb7Ni+xAVSsiOSd5wQPcbBJBnZgIG3EujVdDcdQkGVwab3xa2e9z29uqtMQb/P2gYDeDcNXcBRSWQQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Summary
- Bump `@cloudflare/workers-types` from `5.20260817.1` to `5.20260818.1` in `apps/worker`
- Lockfile updated accordingly

Closes #424
Closes STU-3682

## Test plan
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test:coverage` (704/704)
- [x] `bun run test:e2e:api` (40/40)
- [x] `bun run gate:security`
- [x] Reviewer-01 independent re-verify passed