### PR TITLE
STU-3741: chore(deps): bump workers-types to 5.20260819.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -18,7 +18,7 @@
     "jose": "6.2.9"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260818.1",
+    "@cloudflare/workers-types": "5.20260819.1",
     "@types/bun": "^1.3.14",
     "@vitest/coverage-v8": "^4.1.9",
     "typescript": "7.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
         "jose": "6.2.9",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260818.1",
+        "@cloudflare/workers-types": "5.20260819.1",
         "@types/bun": "^1.3.14",
         "@vitest/coverage-v8": "^4.1.9",
         "typescript": "7.0.2",
@@ -207,7 +207,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260815.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260818.1", "", {}, "sha512-a89taQDbqb7Ni+xAVSsiOSd5wQPcbBJBnZgIG3EujVdDcdQkGVwab3xa2e9z29uqtMQb/P2gYDeDcNXcBRSWQQ=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260819.1", "", {}, "sha512-nUoWrl+16WfocHgXAARAvpQ7dLMF4tSmTvvgLLg5clYhP2j8CYerZ2KC8agnlWHqOAKp45B3F+LcsjNZrZyiRA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Summary

Bump `@cloudflare/workers-types` from `5.20260818.1` to `5.20260819.1` in `apps/worker`.

- Scoped to `apps/worker/package.json` + `bun.lock` only
- Reviewer-01 approved the local change; rebased onto latest `main` before push

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (704 tests)
- [x] `bun --cwd apps/worker test` (101 tests)
- [x] pre-commit gates (coverage, route/page, secrets)

Closes #432
Closes STU-3741