### PR TITLE
chore(deps): bump hono to 4.13.3

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@backy/api": "workspace:*",
-    "hono": "^4.13.2",
+    "hono": "4.13.3",
     "jose": "6.2.9"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@backy/api": "workspace:*",
-        "hono": "^4.13.2",
+        "hono": "4.13.3",
         "jose": "6.2.9",
       },
       "devDependencies": {
@@ -779,7 +779,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.13.2", "", {}, "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA=="],
+    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 


### PR DESCRIPTION
## Summary

- Bump `hono` from `^4.13.2` to `4.13.3` in `apps/worker`
- Sync `bun.lock`

## Test plan

- [x] `bun install --frozen-lockfile`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run test` (704 passed)
- [x] `bun run test:e2e:api` (40/40)
- [x] Reviewer-01 approved `305d7e2`

Closes #434
Closes STU-3739