### PR TITLE
STU-3925: chore(deps): bump @aws-sdk/s3-request-presigner to 3.1114.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -83,7 +83,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1113.0",
-        "@aws-sdk/s3-request-presigner": "^3.1113.0",
+        "@aws-sdk/s3-request-presigner": "^3.1114.0",
         "jszip": "^3.10.1",
         "nanoid": "^6.0.1",
         "tar-stream": "^3.2.0",
@@ -141,7 +141,7 @@
 
     "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.43", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/signature-v4-multi-region": "^3.996.45", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw=="],
 
-    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1113.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/signature-v4-multi-region": "^3.996.45", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-FdbHboJSscXRHnqOGRLN+MvtcYNlxw1+XWMKcKi72nBPxpSTGQA+/zmxEBTlkCvTdIPtl/g383nNY0RiKYPmWQ=="],
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1114.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/signature-v4-multi-region": "^3.996.45", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-z1HQYonZxSJQj6JxWGTyNzOore/46bQ8ZFNAlZJlVs1Ot5oi4bB9AR409mJJrMH7YNjKaEP7bOx+wDoN/RheNQ=="],
 
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.45", "", { "dependencies": { "@aws-sdk/types": "^3.974.4", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1113.0",
-    "@aws-sdk/s3-request-presigner": "^3.1113.0",
+    "@aws-sdk/s3-request-presigner": "^3.1114.0",
     "jszip": "^3.10.1",
     "nanoid": "^6.0.1",
     "tar-stream": "^3.2.0",


### PR DESCRIPTION
## Summary

Bump `@aws-sdk/s3-request-presigner` from 3.1113.0 to 3.1114.0 in `@backy/api`.

Closes STU-3925
Refs #446

## Changes

- `packages/api/package.json`: `^3.1113.0` → `^3.1114.0`
- `bun.lock`: resolved to `3.1114.0`

## Test plan

- [x] Reviewer-01 approved local commit `51a92df`
- [x] `bun install --frozen-lockfile`
- [x] API typecheck
- [x] API Vitest (540 tests)
- [x] root Biome
- [x] pre-push G2 deps scan