### PR TITLE
STU-3926: chore(deps): bump @aws-sdk/client-s3 to 3.1114.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
       "name": "@backy/api",
       "version": "0.0.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1113.0",
+        "@aws-sdk/client-s3": "^3.1114.0",
         "@aws-sdk/s3-request-presigner": "^3.1113.0",
         "jszip": "^3.10.1",
         "nanoid": "^6.0.1",
@@ -117,7 +117,7 @@
   "packages": {
     "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.28", "", { "dependencies": { "@aws-sdk/core": "^3.977.8", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-VCpnmyHQ1IH49ni3LXnQj7DPr7rmcJmzYeiCkYdCcfgNtkvOj38cdcL9lapBWoItZWFACJPFJlymqC7/gem3Gw=="],
 
-    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1113.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.28", "@aws-sdk/core": "^3.977.8", "@aws-sdk/credential-provider-node": "^3.972.80", "@aws-sdk/middleware-sdk-s3": "^3.972.74", "@aws-sdk/signature-v4-multi-region": "^3.996.45", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-NRqdtohoMRyWkEeeznfG1KPN08dclCbl+HFuLPB2v8qPcgoNmTFlLKl9ELiR6hsGXQ4Ur3qvRnoJVEk8ND74pg=="],
+    "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1114.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.28", "@aws-sdk/core": "^3.977.8", "@aws-sdk/credential-provider-node": "^3.972.80", "@aws-sdk/middleware-sdk-s3": "^3.972.74", "@aws-sdk/signature-v4-multi-region": "^3.996.45", "@aws-sdk/types": "^3.974.4", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-ZeAgOtB+CXFaWXph98U7a/XrBlVx1lQ2rCJRWLxLmAaQ9k5lht6DWfwnEcVjdzduK/ySao1tCjq0fBAScGqjAg=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.977.8", "", { "dependencies": { "@aws-sdk/types": "^3.974.4", "@aws-sdk/xml-builder": "^3.972.39", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -39,7 +39,7 @@
     "./handlers/webhook": "./src/handlers/webhook.ts"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1113.0",
+    "@aws-sdk/client-s3": "^3.1114.0",
     "@aws-sdk/s3-request-presigner": "^3.1113.0",
     "jszip": "^3.10.1",
     "nanoid": "^6.0.1",


### PR DESCRIPTION
## Summary
- Bump `@aws-sdk/client-s3` from `3.1113.0` to `3.1114.0` in `@backy/api`
- Lockfile updated via bun; `@aws-sdk/s3-request-presigner` left unchanged (STU-3925 / #450)

Closes STU-3926
Refs #445

## Test plan
- [x] `bun --cwd packages/api typecheck`
- [x] `bun --cwd packages/api test` (27 files / 540 tests)
- [x] pre-commit gates (typecheck ×4, lint-staged, G2 secrets, L2/L3 coverage, root vitest coverage 704 tests)
- [x] Reviewer-01 independent recheck: frozen-lockfile install, API typecheck/unit, full-repo lint

## Coordination
Sibling PR #450 bumps `s3-request-presigner` to 3.1114.0 and will conflict on `packages/api/package.json` / `bun.lock` dependency list segments. Whichever merges second should rebase on latest `main`, keep both bumps, regenerate/verify lockfile, and re-run tests.