### PR TITLE
STU-3922: chore(deps): bump lucide-react to 1.33.0

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
     "@backy/api": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "1.32.0",
+    "lucide-react": "1.33.0",
     "radix-ui": "^1.6.7",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
         "@backy/api": "workspace:*",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "1.32.0",
+        "lucide-react": "1.33.0",
         "radix-ui": "^1.6.7",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -839,7 +839,7 @@
 
     "lint-staged": ["lint-staged@17.3.0", "", { "dependencies": { "picomatch": "^4.0.5", "string-argv": "^0.3.2", "tinyexec": "^1.2.4" }, "optionalDependencies": { "yaml": "^2.9.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw=="],
 
-    "lucide-react": ["lucide-react@1.32.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-txX56hMFnRxPi1f9/nH69YN8uvAO6a7Y1KSWKjCDAtdD9+soEgmWuCt6iRm1pkxUZo2+YntSdsE1L6bIuKoY8Q=="],
+    "lucide-react": ["lucide-react@1.33.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 


### PR DESCRIPTION
## Summary
- Bump `lucide-react` from 1.32.0 to 1.33.0 in `@backy/web`
- Lockfile updated for version, resolution entry, and integrity hash only

Closes STU-3922
Closes nocoo/backy#449

## Test plan
- [x] `bun --cwd apps/web test` (11 files / 58 tests)
- [x] `bun --cwd apps/web typecheck`
- [x] pre-commit gates (typecheck, lint-staged, secrets, route/page coverage, full vitest + coverage)
- [x] Reviewer-01 independent recheck: frozen-lockfile install, web test, typecheck