### PR TITLE
STU-4149: chore(deps): bump @cloudflare/workers-types from 5.20260821.1 to 5.20260822.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "6.2.9"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260821.1",
+    "@cloudflare/workers-types": "5.20260822.1",
     "@types/bun": "^1.4.0",
     "@vitest/coverage-v8": "^4.1.11",
     "typescript": "7.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
         "jose": "6.2.9",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260821.1",
+        "@cloudflare/workers-types": "5.20260822.1",
         "@types/bun": "^1.4.0",
         "@vitest/coverage-v8": "^4.1.11",
         "typescript": "7.0.2",
@@ -207,7 +207,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260821.1", "", {}, "sha512-jZiTISghTPeytJ7eDt5K1AV7df998xGECMgT8oy838VfFLJLROvdLzDaJb0/Jv4WfxO00keNoWt1d6olL7URRg=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260822.1", "", {}, "sha512-z922wN0pEWwYaAcYdncSf11fTPfj2j1Q2n2LCLbtBBhpkIu/aC8fotol5q4ek4isWgTKfWzUx389Dsa+lhF6yw=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Summary
- Bump `@cloudflare/workers-types` from `5.20260821.1` to `5.20260822.1` in `apps/worker`
- Types-only change; no application code updates required

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] monorepo `typecheck`
- [x] monorepo `lint`
- [x] monorepo `test` (52 files / 778 tests)
- [x] pre-commit gates (coverage, secrets, route/page)
- [x] Reviewer-01 approved `012c992`

Closes STU-4149
Refs #468