### PR TITLE
STU-4148: chore(deps): bump jose from 6.2.9 to 6.2.10

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@backy/api": "workspace:*",
     "hono": "4.13.3",
-    "jose": "6.2.9"
+    "jose": "6.2.10"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "5.20260821.1",

--- a/bun.lock
+++ b/bun.lock
@@ -67,7 +67,7 @@
       "dependencies": {
         "@backy/api": "workspace:*",
         "hono": "4.13.3",
-        "jose": "6.2.9",
+        "jose": "6.2.10",
       },
       "devDependencies": {
         "@cloudflare/workers-types": "5.20260821.1",
@@ -795,7 +795,7 @@
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
-    "jose": ["jose@6.2.9", "", {}, "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA=="],
+    "jose": ["jose@6.2.10", "", {}, "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 


### PR DESCRIPTION
## Summary
- Bump `jose` from 6.2.9 to 6.2.10 in `@backy/worker`
- Sync `bun.lock`

Closes STU-4148
Closes #469

## Test plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (52 files / 778 tests)
- [x] Reviewer independent re-verify + `gate:deps` + `wrangler deploy --dry-run`