### PR TITLE
STU-4229: chore(deps) bump workers-types to 5.20260823.1

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,7 +19,7 @@
     "jose": "6.2.10"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "5.20260822.1",
+    "@cloudflare/workers-types": "5.20260823.1",
     "@types/bun": "^1.4.0",
     "@vitest/coverage-v8": "^4.1.11",
     "typescript": "7.0.2",

--- a/bun.lock
+++ b/bun.lock
@@ -70,7 +70,7 @@
         "jose": "6.2.10",
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "5.20260822.1",
+        "@cloudflare/workers-types": "5.20260823.1",
         "@types/bun": "^1.4.0",
         "@vitest/coverage-v8": "^4.1.11",
         "typescript": "7.0.2",
@@ -207,7 +207,7 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260820.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BPvCuMxIQfA47wtYsGbBG6Bcar57Qs7yHqU2jWkT1+sRnL/741/ZbQGP9kVRMQ5fwBMuqNFmQRzAu8gSm7ri/w=="],
 
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260822.1", "", {}, "sha512-z922wN0pEWwYaAcYdncSf11fTPfj2j1Q2n2LCLbtBBhpkIu/aC8fotol5q4ek4isWgTKfWzUx389Dsa+lhF6yw=="],
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@5.20260823.1", "", {}, "sha512-HdBVDR/gecQ5QwB+DZ9kB5yjNZLS85fe8bMB2K/k0xmCvaoMlAFrQQGLaCBYR00j+i9aTkQzwfrPInVZwlMPwQ=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 


### PR DESCRIPTION
## Summary

Bump `@cloudflare/workers-types` in `apps/worker` devDependencies.

| Package | From → To | Workspace | Commit |
|---------|-----------|-----------|--------|
| `@cloudflare/workers-types` | 5.20260822.1 → 5.20260823.1 | `apps/worker` | `238876b` |

Notes:
- Types-only daily bump; package content diff is the version field only.
- Multica Reviewer-01 approved prior to push.

Closes STU-4229
Closes #475

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun run worker:typecheck`
- [x] `bun run worker:test` (6 files / 111 tests)
- [x] `bun run typecheck`
- [x] `bun run test` (52 files / 778 tests)
- [x] `bun run lint`
- [x] pre-commit gates (typecheck, lint-staged, gitleaks, route/page coverage, coverage)
- [x] pre-push `gate:deps` (osv-scanner clean)
- [x] Reviewer-01 Multica approval