### PR TITLE
STU-4391: chore(deps): bump @types/node from 26.2.0 to 26.3.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
-        "@types/node": "26.2.0",
+        "@types/node": "26.3.0",
         "@types/tar-stream": "^3.1.4",
         "@vitest/coverage-v8": "^4.1.11",
         "typescript": "7.0.2",
@@ -583,7 +583,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+    "@types/node": ["@types/node@26.3.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",
-    "@types/node": "26.2.0",
+    "@types/node": "26.3.0",
     "@types/tar-stream": "^3.1.4",
     "@vitest/coverage-v8": "^4.1.11",
     "typescript": "7.0.2",


### PR DESCRIPTION
## Summary

Dependency upgrade: `@types/node` 26.2.0 → 26.3.0

## Changes

- `packages/api/package.json`: `@types/node` 26.2.0 → 26.3.0
- `bun.lock`: updated lockfile

## Verification

- ✅ TypeScript typecheck (all workspaces)
- ✅ L1 tests: 778 tests, 98.24% coverage
- ✅ G1 lint-staged
- ✅ G2 security gates
- ✅ Route coverage: 42/42
- ✅ Page coverage: 8/8

## Review

Reviewed by [@Reviewer-04](mention://member/reviewer-04-id)