### PR TITLE
[deps] hono 4.13.3 → 4.13.4 (STU-4390)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@backy/api": "workspace:*",
-    "hono": "4.13.3",
+    "hono": "4.13.4",
     "jose": "6.2.10"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -66,7 +66,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@backy/api": "workspace:*",
-        "hono": "4.13.3",
+        "hono": "4.13.4",
         "jose": "6.2.10",
       },
       "devDependencies": {
@@ -771,7 +771,7 @@
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
-    "hono": ["hono@4.13.3", "", {}, "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw=="],
+    "hono": ["hono@4.13.4", "", {}, "sha512-AGEwKIyRMHRv1t8Wjwa3LHxQ61X5CqrdFT+4BRNTpqS5aJNnpl5WLjADb7vFlJzI/8uK7T5QLVApCMQKNa3LgQ=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 


### PR DESCRIPTION
## Summary

Bump hono from 4.13.3 to 4.13.4 in `@backy/worker`.

## Changes

- `apps/worker/package.json`: hono 4.13.3 → 4.13.4
- `bun.lock`: updated to reflect worker hono upgrade, no other drift

## Verification

All gates passed locally:
- typecheck: 4 workspace, 0 error
- lint: 208 files
- test:coverage: 778 passed, 98.24% stmts
- test:e2e:api: 43/43 passed
- G2 security: no vulnerabilities
- route coverage: 42/42
- page coverage: 8/8

Closes #482
Closes: STU-4390
