### PR TITLE
Closes STU-4798: upgrade @types/node to 26.5.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
-        "@types/node": "26.4.0",
+        "@types/node": "26.4.1",
         "@types/tar-stream": "^3.1.4",
         "@vitest/coverage-v8": "5.0.0",
         "typescript": "7.0.2",
@@ -583,7 +583,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -91,7 +91,7 @@
       },
       "devDependencies": {
         "@types/bun": "^1.4.0",
-        "@types/node": "26.4.1",
+        "@types/node": "26.5.0",
         "@types/tar-stream": "^3.1.4",
         "@vitest/coverage-v8": "5.0.0",
         "typescript": "7.0.2",
@@ -583,7 +583,7 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
+    "@types/node": ["@types/node@26.5.0", "", { "dependencies": { "undici-types": "~8.9.0" } }, "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
@@ -937,7 +937,7 @@
 
     "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
-    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+    "undici-types": ["undici-types@8.9.0", "", {}, "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg=="],
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",
-    "@types/node": "26.4.0",
+    "@types/node": "26.4.1",
     "@types/tar-stream": "^3.1.4",
     "@vitest/coverage-v8": "5.0.0",
     "typescript": "7.0.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.4.0",
-    "@types/node": "26.4.1",
+    "@types/node": "26.5.0",
     "@types/tar-stream": "^3.1.4",
     "@vitest/coverage-v8": "5.0.0",
     "typescript": "7.0.2",


### PR DESCRIPTION
## Summary

- Upgrade the `packages/api` development dependency `@types/node` from 26.4.0 to 26.5.0.
- Refresh Bun lockfile resolution, including the required `undici-types` 8.9.0 update.

## Validation

- `bun --cwd packages/api typecheck`
- `bun --cwd packages/api test` — 34 files, 604 tests
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run test:coverage` — 52 files, 778 tests; 98.24% statements, 95.70% branches

Closes #572
Closes STU-4798
